### PR TITLE
Fix ci-deploy

### DIFF
--- a/script/ci-build
+++ b/script/ci-build
@@ -5,8 +5,12 @@ set -o pipefail
 
 cd "$(dirname $0)/.."
 
-echo "prepare phantomjs for test"
+echo "prepare packages for test"
+# https://github.com/karma-runner/karma-phantomjs-launcher/issues/120
 npm rebuild phantomjs-prebuilt
+
+# https://github.com/sass/node-sass/issues/1812
+npm rebuild node-sass
 
 echo "yarn test"
 yarn test

--- a/script/ci-build
+++ b/script/ci-build
@@ -5,6 +5,9 @@ set -o pipefail
 
 cd "$(dirname $0)/.."
 
+echo "prepare phantomjs for test"
+npm rebuild phantomjs-prebuilt
+
 echo "yarn test"
 yarn test
 


### PR DESCRIPTION
## WHY & WHAT

CI is red because of `phantomjs`.
I think `npm rebuild phantomjs-prebuilt` is needed before invoking `yarn test`.