### PR TITLE
Fix port mapping on host

### DIFF
--- a/rid/docker-compose.yml
+++ b/rid/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     extra_hosts:
       localhost: "${DOCKER_HOST_IP}"
     ports:
-      - 3000:8080
+      - 8080:8080
     command: tail -f /dev/null
 
   volume:


### PR DESCRIPTION
When the developers invoke `rid yarn dev` to develop this project. The command shows them as below.
```
 DONE  Compiled successfully in 6478ms

> Listening at http://localhost:8080
```
The developers seem that they can access the web application in browser at `http://localhost:8080` but this is doubt. The docker-compose maps the container port `8080` to the host port `3000`, so they cannot access with port `8080`. I fix this problem and enable to access with port `8080`.